### PR TITLE
Limit the number of processed messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ sqsmove --help
 ```
 
 ```text
-sqsmove 1.1.0
+sqsmove 1.2.0
 Usage: sqsmove [options]
 
   -s, --src-queue <name>   source queue name
@@ -26,6 +26,7 @@ Usage: sqsmove [options]
   --dst-dir <path>         destination directory path
   -p, --parallelism <value>
                            parallelism (default: 16)
+  -c, --count <value>      number of messages to process (default: no limit)
   --visibility-timeout <value>
                            visibility timeout (default: 30s). Format: 1d12h35m16s
   --no-delete              do not delete messages after processing
@@ -33,6 +34,26 @@ Usage: sqsmove [options]
   -v, --verbose            verbose output
   -h, --help               prints this usage text
   --version                prints the version
+
+Examples:
+
+  - Move messages from queue A to queue B:
+    sqsmove -s A -d B
+
+  - Move messages from queue A to queue B with parallelism 1:
+    sqsmove -s A -d B -p 1
+
+  - Copy messages from queue A to queue B with visibility timeout 5m:
+    sqsmove -s A -d B --no-delete --visibility-timeout=5m
+
+  - Download messages to directory D:
+    sqsmove -s A --dst-dir D
+
+  - Download N messages to directory D:
+    sqsmove -s A --dst-dir D -c N
+
+  - Upload messages from directory D:
+    sqsmove --src-dir D -d B
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ binAttr,Binary,QUJD
 
 The supported types are `String`, `Number` and `Binary` where binary data is encoded as a Base64 string.
 
+**Download N messages to directory D:**
+
+```bash
+sqsmove -s A --dst-dir D -c N
+```
+
 **Upload messages from directory D:**
 
 ```bash

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   object versions {
-    val awsSdk        = "2.17.53"
+    val awsSdk        = "2.17.56"
     val kindProjector = "0.10.3"
     val logback       = "1.2.6"
     val scopt         = "4.0.1"

--- a/res/graalvm/BUILD.md
+++ b/res/graalvm/BUILD.md
@@ -36,7 +36,7 @@ mv "${REFLECT_CONFIG_FILE}.bak" "${REFLECT_CONFIG_FILE}"
 
 After building with `native-image`, the files:
 
-```
+```text
 -H:JNIConfigurationResources=META-INF/native-image/jni-config.json \
 -H:ReflectionConfigurationResources=META-INF/native-image/reflect-config.json \
 -H:ResourceConfigurationResources=META-INF/native-image/resource-config.json \

--- a/src/main/scala/com/github/gchudnov/sqsmove/SqsConfig.scala
+++ b/src/main/scala/com/github/gchudnov/sqsmove/SqsConfig.scala
@@ -117,7 +117,7 @@ object SqsConfig:
         .valueName("<value>")
         .validate(n => if n > 0 then Right(()) else Left(s"$ArgCountLong should be greater than 0"))
         .action((x, c) => c.copy(count = Some(x)))
-        .text(s"count (default: ${SqsArgs.DefaultCount.fold("no limit")(x => "${x}")})"),
+        .text(s"number of messages to process (default: ${SqsArgs.DefaultCount.fold("no limit")(x => "${x}")})"),
       opt[String](ArgVisibilityTimeoutLong)
         .optional()
         .valueName("<value>")

--- a/src/main/scala/com/github/gchudnov/sqsmove/SqsMove.scala
+++ b/src/main/scala/com/github/gchudnov/sqsmove/SqsMove.scala
@@ -47,7 +47,7 @@ object SqsMove extends ZIOAppDefault:
       dstQueueUrl <- getQueueUrl(dstQueueName)
       _           <- monitor()
       _           <- move(srcQueueUrl, dstQueueUrl)
-      _           <- summary()      
+      _           <- summary()
     yield ()
 
   private def makeDownloadProgram(srcQueueName: String, dstDir: File): ZIO[Has[Sqs] with Has[Clock] with Has[Console], Throwable, Unit] =
@@ -55,7 +55,7 @@ object SqsMove extends ZIOAppDefault:
       srcQueueUrl <- getQueueUrl(srcQueueName)
       _           <- monitor()
       _           <- download(srcQueueUrl, dstDir)
-      _           <- summary()      
+      _           <- summary()
     yield ()
 
   private def makeUploadProgram(srcDir: File, dstQueueName: String): ZIO[Has[Sqs] with Has[Clock] with Has[Console], Throwable, Unit] =
@@ -94,8 +94,9 @@ object SqsMove extends ZIOAppDefault:
     val pMsg        = s"parallelism: ${cfg.parallelism}"
     val vMsg        = if isSrcDir then "" else s"visibility-timeout: ${DurationOps.asString(cfg.visibilityTimeout)}"
     val dMsg        = if isSrcDir then "" else s"no-delete: ${!cfg.isDelete}"
+    val cMsg        = cfg.count.fold("")(n => s"${n} ")
     val paramsMsg   = List(pMsg, vMsg, dMsg).filter(_.nonEmpty).mkString("; ")
-    val msg = s"""Going to ${action} messages '${source}' -> '${destination}'
+    val msg = s"""Going to ${action} ${cMsg}messages '${source}' -> '${destination}'
                  |[${paramsMsg}]
                  |Are you sure? (y|N)""".stripMargin
     for

--- a/src/main/scala/com/github/gchudnov/sqsmove/SqsMove.scala
+++ b/src/main/scala/com/github/gchudnov/sqsmove/SqsMove.scala
@@ -47,6 +47,7 @@ object SqsMove extends ZIOAppDefault:
       dstQueueUrl <- getQueueUrl(dstQueueName)
       _           <- monitor()
       _           <- move(srcQueueUrl, dstQueueUrl)
+      _           <- summary()      
     yield ()
 
   private def makeDownloadProgram(srcQueueName: String, dstDir: File): ZIO[Has[Sqs] with Has[Clock] with Has[Console], Throwable, Unit] =
@@ -54,6 +55,7 @@ object SqsMove extends ZIOAppDefault:
       srcQueueUrl <- getQueueUrl(srcQueueName)
       _           <- monitor()
       _           <- download(srcQueueUrl, dstDir)
+      _           <- summary()      
     yield ()
 
   private def makeUploadProgram(srcDir: File, dstQueueName: String): ZIO[Has[Sqs] with Has[Clock] with Has[Console], Throwable, Unit] =

--- a/src/main/scala/com/github/gchudnov/sqsmove/SqsMove.scala
+++ b/src/main/scala/com/github/gchudnov/sqsmove/SqsMove.scala
@@ -75,9 +75,9 @@ object SqsMove extends ZIOAppDefault:
   private def makeEnv(cfg: SqsConfig): ZLayer[Has[Clock], Throwable, Has[Sqs]] =
     val clockEnv = Clock.any
     val copyEnv = cfg.parallelism match
-      case 0 => AutoSqs.layer(maxConcurrency = sqsMaxConcurrency, initParallelism = 1, visibilityTimeout = cfg.visibilityTimeout, isDelete = cfg.isDelete)
-      case 1 => SerialSqs.layer(maxConcurrency = sqsMaxConcurrency, visibilityTimeout = cfg.visibilityTimeout, isDelete = cfg.isDelete)
-      case m => ParallelSqs.layer(maxConcurrency = sqsMaxConcurrency, parallelism = m, visibilityTimeout = cfg.visibilityTimeout, isDelete = cfg.isDelete)
+      case 0 => AutoSqs.layer(maxConcurrency = sqsMaxConcurrency, initParallelism = 1, limit = cfg.count, visibilityTimeout = cfg.visibilityTimeout, isDelete = cfg.isDelete)
+      case 1 => SerialSqs.layer(maxConcurrency = sqsMaxConcurrency, limit = cfg.count, visibilityTimeout = cfg.visibilityTimeout, isDelete = cfg.isDelete)
+      case m => ParallelSqs.layer(maxConcurrency = sqsMaxConcurrency, parallelism = m, limit = cfg.count, visibilityTimeout = cfg.visibilityTimeout, isDelete = cfg.isDelete)
     val appEnv = clockEnv >>> copyEnv
 
     appEnv

--- a/src/main/scala/com/github/gchudnov/sqsmove/sqs/AutoSqs.scala
+++ b/src/main/scala/com/github/gchudnov/sqsmove/sqs/AutoSqs.scala
@@ -42,7 +42,7 @@ final class AutoSqs(maxConcurrency: Int, initParallelism: Int, limit: Option[Int
       dsRef <- ZRef.make(List.empty[StopPromise]) // active deleters
 
       f0 <- scaleWorkers(cName, cRef, csRef)(
-              newConsumer(cName, csRef)(messages, receiveBatch(makeReceiveRequest(srcQueueUrl, visibilityTimeoutSec = visibilityTimeout.getSeconds, limit = limit)))
+              newConsumer(cName, csRef)(messages, receiveBatch(makeReceiveRequest(srcQueueUrl, visibilityTimeoutSec = visibilityTimeout.getSeconds, batchSize = AwsSqs.maxBatchSize)))
             )
               .schedule(Schedule.spaced(autoUpdateTime))
               .unit

--- a/src/main/scala/com/github/gchudnov/sqsmove/sqs/AwsSqs.scala
+++ b/src/main/scala/com/github/gchudnov/sqsmove/sqs/AwsSqs.scala
@@ -8,13 +8,15 @@ import software.amazon.awssdk.services.sqs.model.*
 
 import scala.collection.immutable.IndexedSeq
 import scala.jdk.CollectionConverters.*
+import java.util.List as JList
 
 object AwsSqs:
   type ReceiptHandle = String
 
-  private val receiveAllAttributeNames        = List("All").asJava
-  private[sqs] val receiveMaxNumberOfMessages = 10
-  private val receiveWaitTimeSeconds          = 20
+  private val receiveAllAttributeNames: JList[String] = List("All").asJava
+  private[sqs] val maxBatchSize: Int                  = 10
+  private[sqs] val waitBatchMillis: Long              = 1000
+  private val receiveWaitTimeSeconds: Int             = 20
 
   def makeHttpClient(maxConcurrency: Int): SdkAsyncHttpClient =
     NettyNioAsyncHttpClient.builder().maxConcurrency(maxConcurrency).build()
@@ -26,13 +28,13 @@ object AwsSqs:
       .httpClient(httpClient)
       .build()
 
-  def makeReceiveRequest(queueUrl: String, visibilityTimeoutSec: Long): ReceiveMessageRequest =
+  def makeReceiveRequest(queueUrl: String, visibilityTimeoutSec: Long, batchSize: Int): ReceiveMessageRequest =
     ReceiveMessageRequest
       .builder()
       .queueUrl(queueUrl)
       .attributeNamesWithStrings(receiveAllAttributeNames)
       .messageAttributeNames(receiveAllAttributeNames)
-      .maxNumberOfMessages(receiveMaxNumberOfMessages)
+      .maxNumberOfMessages(batchSize)
       .waitTimeSeconds(receiveWaitTimeSeconds)
       .visibilityTimeout(visibilityTimeoutSec.toInt)
       .build()

--- a/src/main/scala/com/github/gchudnov/sqsmove/sqs/SerialSqs.scala
+++ b/src/main/scala/com/github/gchudnov/sqsmove/sqs/SerialSqs.scala
@@ -21,7 +21,7 @@ final class SerialSqs(maxConcurrency: Int, limit: Option[Int], visibilityTimeout
              b <- receiveBatch(r)
              _ <- sendBatch(dstQueueUrl, b).flatMap(b => deleteBatch(srcQueueUrl, b).when(isDelete).as(b.size) @@ countMessages).when(b.nonEmpty)
              k <- nRef.updateAndGet(_ - b.size)
-           yield k).repeatUntil(_ > 0)
+           yield k).repeatWhile(_ > 0)
     yield ()
 
   override def download(srcQueueUrl: String, dstDir: File): ZIO[Any, Throwable, Unit] =
@@ -34,7 +34,7 @@ final class SerialSqs(maxConcurrency: Int, limit: Option[Int], visibilityTimeout
              b <- receiveBatch(r)
              _ <- saveBatch(dstDir, b).flatMap(b => deleteBatch(srcQueueUrl, b).when(isDelete).as(b.size) @@ countMessages).when(b.nonEmpty)
              k <- nRef.updateAndGet(_ - b.size)
-           yield k).repeatUntil(_ > 0)
+           yield k).repeatWhile(_ > 0)
     yield ()
 
   override def upload(srcDir: File, dstQueueUrl: String): ZIO[Any, Throwable, Unit] =

--- a/version.sbt
+++ b/version.sbt
@@ -1,3 +1,3 @@
-ThisBuild / version                := "1.1.0"
+ThisBuild / version                := "1.2.0"
 ThisBuild / versionScheme          := Some("early-semver")
 ThisBuild / versionPolicyIntention := Compatibility.BinaryAndSourceCompatible


### PR DESCRIPTION
- limits the number of processed messages with `-c / --count` parameter; fixes #2 
  - sync client
  - parallel client
- update readme